### PR TITLE
テキスト教材のCSVインポート機能を実装

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module TeamProject
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.autoload_paths << Rails.root.join("lib/autoloads")
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Text.delete_all
+ImportCsv.text_data

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -1,0 +1,21 @@
+require "csv"
+
+class ImportCsv
+
+  def self.import(path)
+    list = []
+
+    CSV.foreach(path, headers: true) do |row|
+      list << row.to_h
+    end
+    list
+  end
+
+  def self.text_data
+    list = import('db/csv_data/text_data.csv')
+
+    puts "テキスト教材インポート処理を開始"
+    Text.create!(list)
+    puts "インポート完了!!"
+  end
+end


### PR DESCRIPTION

close #25 

## 実装内容



- db/seeds.rb に，テキスト教材のCSV（db/csv_data/text_data.csv）を読み込み texts テーブルにデータを投入する処理を追加
  - 先に Text.delete_all を入れ，実行時にデータを初期化できるようにしておくこと
  - rails db:seed を実行し，Railsコンソールなどで初期データが入ることを確認すること

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認


