### PR TITLE
日本語ファイル・表示名の設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise'
 gem 'rails-i18n', '~> 6.0'
 gem 'devise-i18n'
+gem 'enum_help'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.9.3)
       devise (>= 4.7.1)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.15.0)
     globalid (0.4.2)
@@ -208,6 +210,7 @@ DEPENDENCIES
   byebug
   devise
   devise-i18n
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,27 @@
+ja:
+  enums:
+    text:
+    movie:
+      genre:
+        code_name: "name"
+        basic: "Basic"
+        git: "Git"
+        ruby: "Ruby"
+        rails: "Ruby on Rails"
+        aws: "AWS"
+        html: "HTML&CSS"
+        js: "JavaScript"
+        ts: "TypeScript"
+        react: "React"
+        vue: "Vue"
+        angular: "Angular"
+        php: "PHP"
+        design_tool: "デザインツールの使い方"
+        design_matter: "実案件の取り方"
+        design_usage: "デザイナーのマーケティング戦略"
+        money_marketing: "マーケティング講座"
+        talk: "全ての勉強会"
+        money_lstep: "Lステップ講座"
+        money_insta: "インスタ講座"
+        live: "プログラミング勉強会"
+        invisible: "非表示"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  activerecord:
+    models:
+      text: テキスト教材
+      movie: 動画教材
+    attributes:
+      text:
+        genre: ジャンル
+        title: タイトル
+        content: 内容
+    attributes:
+      movie:
+        genre: ジャンル
+        title: タイトル
+        url: URL


### PR DESCRIPTION
close #14

## 実装内容
- config/locales/ja.yml に各モデル・カラムの日本語訳を設定
- enum-help を追加
- texts, movies テーブルの genre に対応する表示名 config/locales/enums.ja.yml に追加


## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認